### PR TITLE
Made test001a a UHF job so that the template matrix file used by the …

### DIFF
--- a/GTests/test001a.gjf
+++ b/GTests/test001a.gjf
@@ -1,5 +1,5 @@
 %chk=test001a
-#p test freq output=mat
+#p test uhf freq output=mat
 
 Test calculation for the NIO program on formaldehyde.
 


### PR DESCRIPTION
…program is open shell. This is a bug that I need to fixgit add GTests/test001a.gjf!